### PR TITLE
feat: 135 | suggestions for workflow canvas improvement

### DIFF
--- a/packages/web/src/assets/css/main.scss
+++ b/packages/web/src/assets/css/main.scss
@@ -24,6 +24,7 @@
 @use "particular/splitter-bar";
 @use "particular/radio-button";
 @use "particular/vue-flow";
+@use "particular/el-switch";
 
 //Vue-flow
 @import "@vue-flow/core/dist/style.css";

--- a/packages/web/src/assets/css/particular/_el-switch.scss
+++ b/packages/web/src/assets/css/particular/_el-switch.scss
@@ -1,0 +1,7 @@
+.el-switch.is-checked .el-switch__core{
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+.el-switch__label.is-active{
+  color: var(--color-primary);
+}

--- a/packages/web/src/assets/css/particular/_variables-dark.scss
+++ b/packages/web/src/assets/css/particular/_variables-dark.scss
@@ -72,9 +72,9 @@
   --workflow-transition-auto-border: var(--color-primary);
   --workflow-transition-auto-text: #ffffff;
   /* Dark manual variant - slightly brighter amber for contrast on dark */
-  --workflow-transition-manual-bg: #D07A23;
-  --workflow-transition-manual-border: #C26A17;
-  --workflow-transition-manual-text: #ffffff;
+  --workflow-transition-manual-bg: #dcdcdc;
+  --workflow-transition-manual-border: #dcdcdc;
+  --workflow-transition-manual-text: #333333;
 }
 
 .only-theme-dark {

--- a/packages/web/src/assets/css/particular/_variables-light.scss
+++ b/packages/web/src/assets/css/particular/_variables-light.scss
@@ -72,9 +72,9 @@
   --workflow-transition-auto-border: var(--color-primary);
   --workflow-transition-auto-text: #ffffff;
   /* Pick a distinctive manual color (amber-ish) or adjust as needed */
-  --workflow-transition-manual-bg: #C26A17;
-  --workflow-transition-manual-border: #B25F12;
-  --workflow-transition-manual-text: #ffffff;
+  --workflow-transition-manual-bg: #dcdcdc;
+  --workflow-transition-manual-border: #dcdcdc;
+  --workflow-transition-manual-text: #333333;
 }
 
 .only-theme-light {

--- a/packages/web/src/assets/images/icons/close-small.svg
+++ b/packages/web/src/assets/images/icons/close-small.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 8-3.33333333-3.33333333m3.33333333 3.33333333 3.33333333 3.33333333m-3.33333333-3.33333333 3.33333333-3.33333333m-3.33333333 3.33333333-3.33333333 3.33333333" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.3333"/></svg>

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow.vue
@@ -12,6 +12,7 @@
             :class="{ 'connection-dragging': isDraggingConnection }"
             :fit-view-on-init="true"
             :zoom-on-scroll="false"
+            :zoom-on-double-click="false"
             @nodeDragStop="onNodeDragStop"
             @connect="onConnect"
             @connectStart="onConnectStart"

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/DraggableTransitionEdge.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/DraggableTransitionEdge.vue
@@ -47,6 +47,7 @@
     >
         <div
             class="transition-label"
+            @dblclick="editTransition"
         >
           {{ originalTransitionName }}
         </div>
@@ -567,6 +568,10 @@ function endTransitionDrag(event: MouseEvent) {
   white-space: nowrap;
   background: transparent;
   border: none;
+  &:hover{
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }
 
 .transition-actions {

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/DraggableTransitionEdge.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/DraggableTransitionEdge.vue
@@ -267,9 +267,10 @@ const labelWidth = computed(() => {
 const edgeStyle = computed(() => ({
   stroke: isHighlighted.value ? '#1890ff' : '#999',
   strokeWidth: isHighlighted.value ? 2 : 1,
+  strokeDasharray: isManual.value ? '5,5' : 'none', // Manual transitions dashed, automatic solid
   opacity: shouldDimEdge.value ? 0.8 : 1,
   fill: 'none',
-  transition: 'opacity 0.2s ease, stroke 0.2s ease'
+  transition: 'opacity 0.2s ease, stroke 0.2s ease, stroke-dasharray 0.2s ease'
 }))
 
 const isManual = computed(() => !!props.data?.transitionData?.manual)
@@ -595,7 +596,6 @@ function endTransitionDrag(event: MouseEvent) {
 
   :deep(path) {
     animation: none !important;
-    stroke-dasharray: none !important;
     stroke-dashoffset: 0 !important;
   }
 }
@@ -605,7 +605,7 @@ function endTransitionDrag(event: MouseEvent) {
   color: white;
 
   &:hover {
-    background: #40a9ff;
+    opacity: 0.8;
   }
 }
 
@@ -614,7 +614,7 @@ function endTransitionDrag(event: MouseEvent) {
   color: white;
 
   &:hover {
-    background: #ff7875;
+    opacity: 0.8;
   }
 }
 
@@ -642,5 +642,10 @@ function endTransitionDrag(event: MouseEvent) {
   animation: none !important;
   stroke-dasharray: none !important;
   stroke-dashoffset: 0 !important;
+}
+
+/* Allow transition lines to use stroke-dasharray for manual/automatic differentiation */
+.draggable-transition-edge path:first-child {
+  /* Main transition path - allow dasharray styling */
 }
 </style>

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/DraggableTransitionEdge.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/DraggableTransitionEdge.vue
@@ -558,7 +558,6 @@ function endTransitionDrag(event: MouseEvent) {
 .transition-label {
   font-size: 12px;
   font-weight: 500;
-  color: #fff;
   user-select: none;
   display: flex;
   align-items: center;
@@ -602,7 +601,7 @@ function endTransitionDrag(event: MouseEvent) {
 }
 
 .edit-edge-btn {
-  background: #1890ff;
+  background: var(--color-primary);
   color: white;
 
   &:hover {
@@ -611,7 +610,7 @@ function endTransitionDrag(event: MouseEvent) {
 }
 
 .delete-edge-btn {
-  background: #ff4d4f;
+  background: var(--color-primary);
   color: white;
 
   &:hover {
@@ -626,40 +625,6 @@ function endTransitionDrag(event: MouseEvent) {
 .draggable-transition-edge.highlighted .transition-label {
   color: #1890ff;
   font-weight: 600;
-}
-
-.theme-dark .transition-label-container {
-  background: rgba(0, 0, 0, 0.9);
-  border-color: #434343;
-}
-
-.theme-dark .transition-label-container.manual {
-  background: var(--workflow-transition-manual-bg, var(--color-primary-dark-active));
-  border-color: var(--workflow-transition-manual-border, var(--color-primary-dark-active));
-  color: var(--workflow-transition-manual-text, #fff);
-}
-
-.theme-dark .transition-label-container.auto {
-  background: var(--workflow-transition-auto-bg, var(--color-primary));
-  border-color: var(--workflow-transition-auto-border, var(--color-primary));
-  color: var(--workflow-transition-auto-text, #fff);
-}
-
-.theme-dark .transition-label {
-  color: var(--text-color-regular);
-}
-
-.theme-dark .transition-label-container:hover {
-  border-color: #1890ff;
-}
-
-.theme-dark .draggable-transition-edge.highlighted .transition-label-container {
-  background: rgba(24, 144, 255, 0.2);
-  border-color: #1890ff;
-}
-
-.theme-dark .draggable-transition-edge.highlighted .transition-label {
-  color: #1890ff;
 }
 </style>
 

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/EdgeWithTooltip.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/EdgeWithTooltip.vue
@@ -17,7 +17,10 @@ import { useTransitionHighlight } from './composables/useTransitionHighlight'
 import eventBus from '../../../plugins/eventBus'
 
 interface EdgeData {
-  transitionData?: object
+  transitionData?: {
+    manual?: boolean;
+    [key: string]: any;
+  }
   stateName: string
   transitionName: string
   allTransitions?: Array<{
@@ -155,13 +158,16 @@ const shouldDimEdge = computed(() => {
   return dimBySearch || dimByHover
 })
 
+const isManual = computed(() => !!props.data?.transitionData?.manual)
+
 const edgeStyle = computed(() => {
   return {
     ...props.style,
-  opacity: shouldDimEdge.value ? 0.8 : 1,
+    opacity: shouldDimEdge.value ? 0.8 : 1,
     stroke: shouldDimEdge.value ? '#ccc' : (props.style?.stroke || '#666'),
     strokeWidth: shouldDimEdge.value ? 1 : (props.style?.strokeWidth || 2),
-    transition: 'opacity 0.3s ease, stroke 0.3s ease, stroke-width 0.3s ease'
+    strokeDasharray: isManual.value ? '5,5' : 'none', // Manual transitions dashed, automatic solid
+    transition: 'opacity 0.3s ease, stroke 0.3s ease, stroke-width 0.3s ease, stroke-dasharray 0.3s ease'
   }
 })
 </script>

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/EditEdgeConditionalDialog.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/EditEdgeConditionalDialog.vue
@@ -9,6 +9,7 @@
     <template #header>
       <div class="edit-edge-conditional-dialog__header">
         <span class="edit-edge-conditional-dialog__title">Edit Transition Data</span>
+        <el-divider direction="vertical" />
         <div class="edit-edge-conditional-dialog__mode-toggle">
           <span class="edit-edge-conditional-dialog__mode-label">Mode:</span>
           <el-switch
@@ -224,7 +225,6 @@ watch(conditionText, (newValue) => {
 .edit-edge-conditional-dialog {
   &__header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     padding: 0;
   }
@@ -245,11 +245,6 @@ watch(conditionText, (newValue) => {
     font-size: 14px;
     color: var(--text-color-regular);
     font-weight: 500;
-  }
-
-  &__switch {
-    --el-switch-on-color: var(--color-primary);
-    --el-switch-off-color: #dcdfe6;
   }
 
   &__form {

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/Node.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/Node.vue
@@ -84,38 +84,38 @@
         />
       </div>
       <div class="node-actions">
-        <button
-            v-if="!isEditing"
-            @click="startInlineEdit"
-            class="edit-state-btn"
-            title="Edit state name"
-        >
-          <EditIcon/>
-        </button>
-        <button
-            v-if="isEditing"
-            @click="finishEdit"
-            class="confirm-edit-btn"
-            title="Confirm changes"
-        >
-          <CheckIcon/>
-        </button>
-        <button
-            v-if="isEditing"
-            @click="cancelEdit"
-            class="cancel-edit-btn"
-            title="Cancel editing"
-        >
-          <CloseIcon/>
-        </button>
-        <button
-            v-if="!isEditing"
-            @click="deleteState"
-            class="delete-state-btn"
-            title="Delete state"
-        >
-          <TrashSmallIcon/>
-        </button>
+        <template v-if="isEditing">
+          <button
+              @click="finishEdit"
+              class="confirm-edit-btn"
+              title="Confirm changes"
+          >
+            <CheckIcon/>
+          </button>
+          <button
+              @click="cancelEdit"
+              class="cancel-edit-btn"
+              title="Cancel editing"
+          >
+            <CloseSmallIcon/>
+          </button>
+        </template>
+        <template v-else>
+          <button
+              @click="startInlineEdit"
+              class="edit-state-btn"
+              title="Edit state name"
+          >
+            <EditIcon/>
+          </button>
+          <button
+              @click="deleteState"
+              class="delete-state-btn"
+              title="Delete state"
+          >
+            <TrashSmallIcon/>
+          </button>
+        </template>
       </div>
     </div>
   </div>
@@ -131,7 +131,7 @@ import eventBus from '../../../plugins/eventBus'
 import TrashSmallIcon from "@/assets/images/icons/trash-small.svg"
 import EditIcon from '@/assets/images/icons/edit.svg';
 import CheckIcon from '@/assets/images/icons/check.svg';
-import CloseIcon from '@/assets/images/icons/close.svg';
+import CloseSmallIcon from '@/assets/images/icons/close-small.svg';
 import PlayIcon from '@/assets/images/icons/play.svg';
 import CircleIcon from '@/assets/images/icons/circle.svg';
 import StopIcon from '@/assets/images/icons/stop.svg';
@@ -211,10 +211,10 @@ const deleteState = async () => {
 // Inline editing methods
 const startInlineEdit = () => {
   if (isEditing.value) return
-  
+
   isEditing.value = true
   editingName.value = props.data.label
-  
+
   nextTick(() => {
     if (editInput.value?.focus) {
       editInput.value.focus()
@@ -224,27 +224,27 @@ const startInlineEdit = () => {
 
 const finishEdit = () => {
   if (!isEditing.value) return
-  
+
   const newName = editingName.value.trim()
-  
+
   // Validate the name
   if (!newName) {
     cancelEdit()
     return
   }
-  
+
   if (newName.length < 2) {
     cancelEdit()
     return
   }
-  
+
   if (newName !== props.data.label) {
     eventBus.$emit('rename-state', {
       oldName: props.data.label,
       newName: newName
     })
   }
-  
+
   isEditing.value = false
   editingName.value = ''
 }
@@ -286,9 +286,10 @@ const cancelEdit = () => {
   align-items: center;
   gap: 6px;
   cursor: text;
-  
+
   &:hover .node-name {
     text-decoration: underline;
+    cursor: pointer;
   }
 }
 
@@ -298,14 +299,14 @@ const cancelEdit = () => {
 
 .inline-edit-input {
   width: 150px;
-  
+
   :deep(.el-input__wrapper) {
     background-color: rgba(255, 255, 255, 0.9) !important;
     border-radius: 3px;
     padding: 2px 6px;
     box-shadow: none;
     border: 1px solid rgba(255, 255, 255, 0.3);
-    
+
     .el-input__inner {
       color: #333 !important;
       font-size: 13px;
@@ -315,7 +316,7 @@ const cancelEdit = () => {
       line-height: 18px;
     }
   }
-  
+
   :deep(.el-input__wrapper:focus) {
     border-color: var(--color-primary);
     box-shadow: 0 0 0 2px rgba(64, 158, 255, 0.2);
@@ -380,7 +381,7 @@ const cancelEdit = () => {
   svg {
     width: 12px;
     height: auto;
-    fill: currentColor;
+
     &:hover {
       opacity: 0.5;
     }
@@ -388,25 +389,11 @@ const cancelEdit = () => {
 }
 
 .confirm-edit-btn {
-  background: rgba(76, 175, 80, 0.2);
-  border-color: rgba(76, 175, 80, 0.4);
-  color: rgba(76, 175, 80, 1);
-  
-  &:hover {
-    background: rgba(76, 175, 80, 0.3);
-    border-color: rgba(76, 175, 80, 0.6);
-  }
+
 }
 
 .cancel-edit-btn {
-  background: rgba(244, 67, 54, 0.2);
-  border-color: rgba(244, 67, 54, 0.4);
-  color: rgba(244, 67, 54, 1);
-  
-  &:hover {
-    background: rgba(244, 67, 54, 0.3);
-    border-color: rgba(244, 67, 54, 0.6);
-  }
+
 }
 
 .node-footer {

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/Node.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/Node.vue
@@ -85,6 +85,14 @@
       </div>
       <div class="node-actions">
         <button
+            v-if="!isEditing"
+            @click="startInlineEdit"
+            class="edit-state-btn"
+            title="Edit state name"
+        >
+          <EditIcon/>
+        </button>
+        <button
             v-if="isEditing"
             @click="finishEdit"
             class="confirm-edit-btn"
@@ -121,6 +129,7 @@ import {useDropdownManager} from './composables/useDropdownManager'
 import {useTransitionHighlight} from './composables/useTransitionHighlight'
 import eventBus from '../../../plugins/eventBus'
 import TrashSmallIcon from "@/assets/images/icons/trash-small.svg"
+import EditIcon from '@/assets/images/icons/edit.svg';
 import CheckIcon from '@/assets/images/icons/check.svg';
 import CloseIcon from '@/assets/images/icons/close.svg';
 import PlayIcon from '@/assets/images/icons/play.svg';
@@ -209,7 +218,6 @@ const startInlineEdit = () => {
   nextTick(() => {
     if (editInput.value?.focus) {
       editInput.value.focus()
-      editInput.value.select()
     }
   })
 }
@@ -350,6 +358,7 @@ const cancelEdit = () => {
   margin-left: 8px;
 }
 
+.edit-state-btn,
 .delete-state-btn,
 .confirm-edit-btn,
 .cancel-edit-btn {

--- a/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/Node.vue
+++ b/packages/web/src/components/ChatBot/ChatBotEditorWorkflow/Node.vue
@@ -61,7 +61,7 @@
     />
 
     <div class="node-header">
-      <div class="node-title">
+      <div class="node-title" @dblclick="startInlineEdit">
         <span v-if="data.isInitial" class="node-icon initial-icon" title="Initial state">
           <PlayIcon/>
         </span>
@@ -71,17 +71,37 @@
         <span v-else class="node-icon default-icon" title="State">
           <CircleIcon/>
         </span>
-        {{ data.label }}
+        <span v-if="!isEditing" class="node-name">{{ data.label }}</span>
+        <el-input
+            v-if="isEditing"
+            v-model="editingName"
+            @blur="finishEdit"
+            @keyup.enter="finishEdit"
+            @keyup.escape="cancelEdit"
+            size="small"
+            class="inline-edit-input"
+            ref="editInput"
+        />
       </div>
       <div class="node-actions">
         <button
-            @click="editStateName"
-            class="edit-state-btn"
-            title="Edit state name"
+            v-if="isEditing"
+            @click="finishEdit"
+            class="confirm-edit-btn"
+            title="Confirm changes"
         >
-          <EditIcon/>
+          <CheckIcon/>
         </button>
         <button
+            v-if="isEditing"
+            @click="cancelEdit"
+            class="cancel-edit-btn"
+            title="Cancel editing"
+        >
+          <CloseIcon/>
+        </button>
+        <button
+            v-if="!isEditing"
             @click="deleteState"
             class="delete-state-btn"
             title="Delete state"
@@ -94,14 +114,15 @@
 </template>
 
 <script setup lang="ts">
-import {computed, ref, onMounted, onUnmounted} from 'vue'
+import {computed, ref, onMounted, onUnmounted, nextTick} from 'vue'
 import {Handle, Position} from '@vue-flow/core'
-import {ElMessageBox} from 'element-plus'
+import {ElMessageBox, ElInput} from 'element-plus'
 import {useDropdownManager} from './composables/useDropdownManager'
 import {useTransitionHighlight} from './composables/useTransitionHighlight'
 import eventBus from '../../../plugins/eventBus'
 import TrashSmallIcon from "@/assets/images/icons/trash-small.svg"
-import EditIcon from '@/assets/images/icons/edit.svg';
+import CheckIcon from '@/assets/images/icons/check.svg';
+import CloseIcon from '@/assets/images/icons/close.svg';
 import PlayIcon from '@/assets/images/icons/play.svg';
 import CircleIcon from '@/assets/images/icons/circle.svg';
 import StopIcon from '@/assets/images/icons/stop.svg';
@@ -130,6 +151,11 @@ const {
 } = useTransitionHighlight()
 
 const isHoveringDeleteBtn = ref(false)
+
+// Inline editing state
+const isEditing = ref(false)
+const editingName = ref('')
+const editInput = ref()
 
 const handleDocumentClick = (event: Event) => {
   const target = event.target as Element
@@ -173,37 +199,51 @@ const deleteState = async () => {
   }
 }
 
-const editStateName = async () => {
-  try {
-    const {value: newName} = await ElMessageBox.prompt(
-        'Enter new state name:',
-        'Edit State Name',
-        {
-          confirmButtonText: 'Save',
-          cancelButtonText: 'Cancel',
-          inputValue: props.data.label,
-          inputValidator: (value: string) => {
-            if (!value || value.trim() === '') {
-              return 'State name cannot be empty'
-            }
-            if (value.trim().length < 2) {
-              return 'State name must be at least 2 characters long'
-            }
-            return true
-          },
-          inputErrorMessage: 'Invalid state name'
-        }
-    )
-
-    if (newName && newName.trim() !== props.data.label) {
-      eventBus.$emit('rename-state', {
-        oldName: props.data.label,
-        newName: newName.trim()
-      })
+// Inline editing methods
+const startInlineEdit = () => {
+  if (isEditing.value) return
+  
+  isEditing.value = true
+  editingName.value = props.data.label
+  
+  nextTick(() => {
+    if (editInput.value?.focus) {
+      editInput.value.focus()
+      editInput.value.select()
     }
-  } catch {
-    // User cancelled the edit
+  })
+}
+
+const finishEdit = () => {
+  if (!isEditing.value) return
+  
+  const newName = editingName.value.trim()
+  
+  // Validate the name
+  if (!newName) {
+    cancelEdit()
+    return
   }
+  
+  if (newName.length < 2) {
+    cancelEdit()
+    return
+  }
+  
+  if (newName !== props.data.label) {
+    eventBus.$emit('rename-state', {
+      oldName: props.data.label,
+      newName: newName
+    })
+  }
+  
+  isEditing.value = false
+  editingName.value = ''
+}
+
+const cancelEdit = () => {
+  isEditing.value = false
+  editingName.value = ''
 }
 </script>
 
@@ -237,6 +277,41 @@ const editStateName = async () => {
   display: flex;
   align-items: center;
   gap: 6px;
+  cursor: text;
+  
+  &:hover .node-name {
+    text-decoration: underline;
+  }
+}
+
+.node-name {
+  user-select: none;
+}
+
+.inline-edit-input {
+  width: 150px;
+  
+  :deep(.el-input__wrapper) {
+    background-color: rgba(255, 255, 255, 0.9) !important;
+    border-radius: 3px;
+    padding: 2px 6px;
+    box-shadow: none;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    
+    .el-input__inner {
+      color: #333 !important;
+      font-size: 13px;
+      font-weight: 600;
+      padding: 0;
+      height: 18px;
+      line-height: 18px;
+    }
+  }
+  
+  :deep(.el-input__wrapper:focus) {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px rgba(64, 158, 255, 0.2);
+  }
 }
 
 .node-icon {
@@ -275,8 +350,9 @@ const editStateName = async () => {
   margin-left: 8px;
 }
 
-.edit-state-btn,
-.delete-state-btn {
+.delete-state-btn,
+.confirm-edit-btn,
+.cancel-edit-btn {
   background: rgba(255, 255, 255, 0.1);
   border: 1px solid rgba(255, 255, 255, 0.2);
   color: rgba(255, 255, 255, 0.7);
@@ -299,6 +375,28 @@ const editStateName = async () => {
     &:hover {
       opacity: 0.5;
     }
+  }
+}
+
+.confirm-edit-btn {
+  background: rgba(76, 175, 80, 0.2);
+  border-color: rgba(76, 175, 80, 0.4);
+  color: rgba(76, 175, 80, 1);
+  
+  &:hover {
+    background: rgba(76, 175, 80, 0.3);
+    border-color: rgba(76, 175, 80, 0.6);
+  }
+}
+
+.cancel-edit-btn {
+  background: rgba(244, 67, 54, 0.2);
+  border-color: rgba(244, 67, 54, 0.4);
+  color: rgba(244, 67, 54, 1);
+  
+  &:hover {
+    background: rgba(244, 67, 54, 0.3);
+    border-color: rgba(244, 67, 54, 0.6);
   }
 }
 


### PR DESCRIPTION
This pull request introduces several improvements to the chatbot workflow editor, focusing on user experience and visual clarity. The main enhancements include inline editing for node names, a more intuitive manual/automatic mode toggle for transitions, and clearer differentiation of manual transitions in the workflow diagram. Additionally, style updates ensure better theme consistency and component appearance.

**Workflow Editor UX Improvements:**

* Added inline editing for node names in `Node.vue`, allowing users to double-click a node title to rename it directly, with validation and cancel/confirm controls. [[1]](diffhunk://#diff-4f0d039c4002e35b7307d958b71a7d9dcb05172d9f0b326cabaa89d6d3e43f32L64-R64) [[2]](diffhunk://#diff-4f0d039c4002e35b7307d958b71a7d9dcb05172d9f0b326cabaa89d6d3e43f32L74-R105) [[3]](diffhunk://#diff-4f0d039c4002e35b7307d958b71a7d9dcb05172d9f0b326cabaa89d6d3e43f32R118-R134) [[4]](diffhunk://#diff-4f0d039c4002e35b7307d958b71a7d9dcb05172d9f0b326cabaa89d6d3e43f32R164-R168) [[5]](diffhunk://#diff-4f0d039c4002e35b7307d958b71a7d9dcb05172d9f0b326cabaa89d6d3e43f32L176-R254)
* Enabled double-click editing of transition labels in `DraggableTransitionEdge.vue` for quick access to transition data.

**Transition Mode and Data Handling:**

* Redesigned the transition editing dialog (`EditEdgeConditionalDialog.vue`) to include a manual/automatic mode toggle using an `el-switch`, synchronizing with the `manual` property in transition data, and updating the JSON editor accordingly. [[1]](diffhunk://#diff-33cfca17fe13839ff9a953e0bad660a6625069b4635c50198ace4c1ad9ffd45fL6-R26) [[2]](diffhunk://#diff-33cfca17fe13839ff9a953e0bad660a6625069b4635c50198ace4c1ad9ffd45fR57-R81) [[3]](diffhunk://#diff-33cfca17fe13839ff9a953e0bad660a6625069b4635c50198ace4c1ad9ffd45fL70-R148) [[4]](diffhunk://#diff-33cfca17fe13839ff9a953e0bad660a6625069b4635c50198ace4c1ad9ffd45fR202) [[5]](diffhunk://#diff-33cfca17fe13839ff9a953e0bad660a6625069b4635c50198ace4c1ad9ffd45fR213-R216)
* Updated transition data types and edge rendering logic to consistently support and display the `manual` flag, including in tooltips and edge styles. [[1]](diffhunk://#diff-aed6d2e4ccd6754ac7eaf9941059a36405f929d5a9a48ee2786cb65935ecdf0dL20-R23) [[2]](diffhunk://#diff-aed6d2e4ccd6754ac7eaf9941059a36405f929d5a9a48ee2786cb65935ecdf0dR161-R170)

**Visual Differentiation and Styling:**

* Manual transitions are now visually distinguished by dashed lines in both `DraggableTransitionEdge.vue` and `EdgeWithTooltip.vue`, improving workflow clarity. [[1]](diffhunk://#diff-4de7c79a2b2c5717e45ae746672eb563dbe3e9439286c5cf0ba77dc5395462abR271-R274) [[2]](diffhunk://#diff-aed6d2e4ccd6754ac7eaf9941059a36405f929d5a9a48ee2786cb65935ecdf0dR161-R170) [[3]](diffhunk://#diff-4de7c79a2b2c5717e45ae746672eb563dbe3e9439286c5cf0ba77dc5395462abR651-R655)
* Refined styles for transition labels, buttons, and dialog headers to use theme variables and improve appearance, including hover effects and color consistency for light/dark modes. [[1]](diffhunk://#diff-4de7c79a2b2c5717e45ae746672eb563dbe3e9439286c5cf0ba77dc5395462abL561) [[2]](diffhunk://#diff-4de7c79a2b2c5717e45ae746672eb563dbe3e9439286c5cf0ba77dc5395462abR571-R574) [[3]](diffhunk://#diff-4de7c79a2b2c5717e45ae746672eb563dbe3e9439286c5cf0ba77dc5395462abL599-R622) [[4]](diffhunk://#diff-33cfca17fe13839ff9a953e0bad660a6625069b4635c50198ace4c1ad9ffd45fR226-R249)

**Theme Consistency:**

* Updated manual transition colors for both dark and light themes to use neutral backgrounds and dark text for improved contrast and accessibility. [[1]](diffhunk://#diff-77922f13dac48ebd3dedcdf891049d7e53b27ae91e6a0318633a2be0e9852292L75-R77) [[2]](diffhunk://#diff-62494220257864b51ad657268bec3cdfad0646852d47aa27bde935cf3034004dL75-R77)
* Added styling for the `el-switch` component to match the primary color theme. [[1]](diffhunk://#diff-c2a11cfd2a4f0b6cf40346e4d33826686c9719dc3d18306bbebd8b2938a9eebcR1-R7) [[2]](diffhunk://#diff-4d5e9be5752674fbc83b3d43b003555b397e202fd6b81c591d5c26277f4ab49fR27)