### PR TITLE
fix: 131 |  bug for desktop app authorization

### DIFF
--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -78,11 +78,46 @@ const createWindow = () => {
     // and load the index.html of the app.
     loadAppUrl();
 
-    // Open the DevTools.
-    if (process.env.NODE_ENV === 'development') {
+        // Open the DevTools.
+    // if (process.env.NODE_ENV === 'development') {
         mainWindow.webContents.openDevTools();
-    }
+    // }
     
+    // Отслеживаем навигацию для инжекции кастомных элементов на Auth0 страницы
+    mainWindow.webContents.on('did-finish-load', () => {
+        const currentUrl = mainWindow.webContents.getURL();
+        console.log('🔥 Page loaded:', currentUrl);
+
+        // Проверяем, если это страница Auth0 login
+        if (currentUrl.includes('auth0.com') && currentUrl.includes('/u/login')) {
+            console.log('🔥 Detected Auth0 login page, injecting custom message...');
+
+            const jsCode = `
+                // Проверяем, не добавили ли уже сообщение
+                if (document.getElementById('electron-auth-message')) {
+                    console.log('Custom message already exists');
+                } else {
+                    console.log('Adding custom message to Auth0 page');
+                    
+                    // Создаем кастомное сообщение
+                    const customMessage = document.createElement('div');
+                    customMessage.id = 'electron-auth-message';
+                    customMessage.style = 'background: #0D8484; color: #fff; padding: 15px 20px; text-align: center; font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; font-size: 15px; font-weight: 600; box-shadow: 0 4px 15px rgba(0,0,0,0.2);';
+                    customMessage.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; gap: 10px;"><span style="font-size: 20px;">🚀</span><span>Authorization</span></div><div style="font-size: 13px; margin-top: 5px; opacity: 0.95; font-weight: 400;">Sign in to access your personal AI assistant • Press ESC to cancel</div>';
+                    
+                    // Вставляем в начало body
+                    document.body.insertBefore(customMessage, document.body.firstChild);
+                    
+                    console.log('✅ Custom message added to Auth0 login page');
+                }
+            `;
+
+            mainWindow.webContents.executeJavaScript(jsCode).catch(err => {
+                console.error('🔥 Failed to inject custom message:', err);
+            });
+        }
+    });
+
     // Создаем сервер для Auth0 callback после создания окна
     createAuthCallbackServer();
 };

--- a/packages/web/src/components/AuthState/AuthStateAvatar.vue
+++ b/packages/web/src/components/AuthState/AuthStateAvatar.vue
@@ -84,14 +84,24 @@ function onClickSettings() {
 
 function onClickLogout() {
   visibleCard.value = false;
-  authStore.logout(() => {
-    logout({
-      logoutParams: {
-        returnTo: window.location.origin
-      }
+  const isElectron = import.meta.env.VITE_IS_ELECTRON;
+  
+  if (isElectron) {
+    // В Electron только очищаем стейт, без редиректа через Auth0
+    authStore.logout();
+    // Используем роутер для навигации вместо reload
+    router.push('/');
+  } else {
+    // В браузере используем полный logout через Auth0
+    authStore.logout(() => {
+      logout({
+        logoutParams: {
+          returnTo: window.location.origin
+        }
+      });
     });
-  });
-  router.push('/');
+    router.push('/');
+  }
 }
 
 function onToggleCard() {

--- a/packages/web/src/components/LoginButton/LoginButton.vue
+++ b/packages/web/src/components/LoginButton/LoginButton.vue
@@ -9,11 +9,11 @@ import {LOGIN_REDIRECT_URL} from "@/helpers/HelperConstants";
 
 const helperStorage = new HelperStorage();
 
-const {loginWithRedirect} = useAuth0();
+const {loginWithRedirect, loginWithPopup} = useAuth0();
 
 function onClick() {
   helperStorage.set(LOGIN_REDIRECT_URL, '/home');
-  loginWithRedirect({
+  loginWithPopup({
     authorizationParams: {
       prompt: 'login',
       scope: 'openid profile email offline_access'

--- a/packages/web/src/components/LoginButton/LoginButton.vue
+++ b/packages/web/src/components/LoginButton/LoginButton.vue
@@ -9,11 +9,11 @@ import {LOGIN_REDIRECT_URL} from "@/helpers/HelperConstants";
 
 const helperStorage = new HelperStorage();
 
-const {loginWithRedirect, loginWithPopup} = useAuth0();
+const {loginWithRedirect} = useAuth0();
 
 function onClick() {
   helperStorage.set(LOGIN_REDIRECT_URL, '/home');
-  loginWithPopup({
+  loginWithRedirect({
     authorizationParams: {
       prompt: 'login',
       scope: 'openid profile email offline_access'

--- a/packages/web/src/plugins/auth0.ts
+++ b/packages/web/src/plugins/auth0.ts
@@ -2,11 +2,23 @@ import {createAuth0} from '@auth0/auth0-vue';
 
 export default {
   install: (app) => {
+    // Определяем правильный redirect_uri для Electron
+    const isElectron = import.meta.env.VITE_IS_ELECTRON;
+    let redirectUri = import.meta.env.VITE_APP_AUTH0_REDIRECT_URI;
+    
+    if (isElectron) {
+      // Для Electron используем file:// протокол или специальный схема
+      redirectUri = 'http://localhost:3009';
+    } else {
+      // Для веба добавляем параметр
+      redirectUri = `${redirectUri}?auth0=true`;
+    }
+
     const auth0 = createAuth0({
       domain: import.meta.env.VITE_APP_AUTH0_DOMAIN,
       clientId: import.meta.env.VITE_APP_AUTH0_CLIENT_ID,
       authorizationParams: {
-        redirect_uri: `${import.meta.env.VITE_APP_AUTH0_REDIRECT_URI}?auth0=true`,
+        redirect_uri: redirectUri,
         audience: import.meta.env.VITE_APP_AUTH0_AUDIENCE,
         organization: import.meta.env.VITE_APP_AUTH0_ORGANIZATION,
         scope: 'openid profile email offline_access'


### PR DESCRIPTION
This pull request introduces significant improvements to the Electron authentication flow, specifically for handling Auth0 login and logout in the desktop app. The main changes are the addition of a local HTTP server to handle Auth0 callbacks, custom UI enhancements for the Auth0 login page, and environment-specific logic to differentiate authentication behavior between Electron and the web app.

**Electron authentication flow enhancements:**

- Added a local HTTP server (`createAuthCallbackServer`) in `main.ts` to handle Auth0 authentication callbacks directly within the Electron app, including serving a confirmation page and redirecting the main window with authentication tokens.
- Injected a custom message/banner into the Auth0 login page in Electron to improve user experience and provide context during authentication.
- Registered a global Escape shortcut in Electron to allow users to cancel authentication and return to the main app, improving usability.
- Updated the logout logic in `AuthStateAvatar.vue` to clear authentication state and navigate home without redirecting to Auth0 when running inside Electron, ensuring a smooth logout experience. [[1]](diffhunk://#diff-93907163e0a2935832acb8da092fcdafbdb2c2c519c39b62c3bd5f0b038c74c6R87-R95) [[2]](diffhunk://#diff-93907163e0a2935832acb8da092fcdafbdb2c2c519c39b62c3bd5f0b038c74c6R105)

**Environment-specific Auth0 configuration:**

- Modified the Auth0 plugin (`auth0.ts`) to set the `redirect_uri` dynamically based on the environment: using a local HTTP server for Electron and a query parameter for the web, ensuring proper authentication flow in both contexts.