### PR TITLE
Fix the bug for desktop app authorization

### DIFF
--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -108,9 +108,9 @@ const createWindow = () => {
     loadAppUrl();
 
     // Open the DevTools for development env
-    // if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development') {
         mainWindow.webContents.openDevTools();
-    // }
+    }
 
     mainWindow.webContents.on('did-finish-load', () => {
         const currentUrl = mainWindow.webContents.getURL();

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,4 +1,4 @@
-import {app, BrowserWindow, screen, Notification, globalShortcut} from 'electron';
+import {app, BrowserWindow, screen, Notification, globalShortcut, ipcMain} from 'electron';
 import path from 'path';
 import started from 'electron-squirrel-startup';
 import {updateElectronApp} from 'update-electron-app';
@@ -84,6 +84,14 @@ function loadAppUrl(){
         mainWindow.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`));
     }
 }
+
+// Обработчик IPC сообщений для перезагрузки главного окна
+ipcMain.handle('reload-main-window', () => {
+    console.log('🔄 Reloading main window by request');
+    if (mainWindow && !mainWindow.isDestroyed()) {
+        loadAppUrl();
+    }
+});
 
 const createWindow = () => {
     const {width, height} = screen.getPrimaryDisplay().workAreaSize;

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -1,2 +1,12 @@
 // See the Electron documentation for details on how to use preload scripts:
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+// Предоставляем API для renderer процесса
+contextBridge.exposeInMainWorld('electronAPI', {
+  reloadMainWindow: () => {
+    console.log('🔄 Reloading main window via IPC');
+    ipcRenderer.invoke('reload-main-window');
+  }
+});

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -32,6 +32,7 @@ const assistantStore = useAssistantStore();
 const detectTheme = useDetectTheme();
 
 onMounted(() => {
+  console.log('localtion', window.location);
   const {getAccessTokenSilently} = useAuth0()
 
   setTokenGetter(async () => {

--- a/packages/web/src/clients/interceptors/refreshToken.ts
+++ b/packages/web/src/clients/interceptors/refreshToken.ts
@@ -27,7 +27,7 @@ const refreshToken = (instance: AxiosInstance): void => {
 
                     autoLogoutTimeout = setTimeout(() => {
                         authStore.logout();
-                        window.location.href = "/";
+                        window.location.href = window.location.origin + "/";
                     }, 10000);
 
                     await refreshAccessTokenPromise;
@@ -48,14 +48,14 @@ const refreshToken = (instance: AxiosInstance): void => {
                     return instance.request(originalConfig);
                 } catch (e) {
                     authStore.logout();
-                    window.location.href = "/";
+                    window.location.href = window.location.origin + "/";
                 } finally {
                     if (autoLogoutTimeout) clearTimeout(autoLogoutTimeout);
                     autoLogoutTimeout = null;
                 }
             } else if (response?.status === 401 && originalConfig?.__isRetryRequest) {
                 authStore.logout();
-                window.location.href = "/";
+                window.location.href = window.location.origin + "/";
             }
 
             return Promise.reject(error);

--- a/packages/web/src/clients/interceptors/refreshToken.ts
+++ b/packages/web/src/clients/interceptors/refreshToken.ts
@@ -27,7 +27,12 @@ const refreshToken = (instance: AxiosInstance): void => {
 
                     autoLogoutTimeout = setTimeout(() => {
                         authStore.logout();
-                        window.location.href = window.location.origin + "/";
+                        // Проверяем, работаем ли мы в Electron
+                        if (import.meta.env.VITE_IS_ELECTRON && window.electronAPI?.reloadMainWindow) {
+                            window.electronAPI.reloadMainWindow();
+                        } else {
+                            window.location.href = window.location.origin + "/";
+                        }
                     }, 10000);
 
                     await refreshAccessTokenPromise;
@@ -48,14 +53,24 @@ const refreshToken = (instance: AxiosInstance): void => {
                     return instance.request(originalConfig);
                 } catch (e) {
                     authStore.logout();
-                    window.location.href = window.location.origin + "/";
+                    // Проверяем, работаем ли мы в Electron
+                    if (import.meta.env.VITE_IS_ELECTRON && window.electronAPI?.reloadMainWindow) {
+                        window.electronAPI.reloadMainWindow();
+                    } else {
+                        window.location.href = window.location.origin + "/";
+                    }
                 } finally {
                     if (autoLogoutTimeout) clearTimeout(autoLogoutTimeout);
                     autoLogoutTimeout = null;
                 }
             } else if (response?.status === 401 && originalConfig?.__isRetryRequest) {
                 authStore.logout();
-                window.location.href = window.location.origin + "/";
+                // Проверяем, работаем ли мы в Electron
+                if (import.meta.env.VITE_IS_ELECTRON && window.electronAPI?.reloadMainWindow) {
+                    window.electronAPI.reloadMainWindow();
+                } else {
+                    window.location.href = window.location.origin + "/";
+                }
             }
 
             return Promise.reject(error);

--- a/packages/web/src/plugins/auth0.ts
+++ b/packages/web/src/plugins/auth0.ts
@@ -2,20 +2,11 @@ import {createAuth0} from '@auth0/auth0-vue';
 
 export default {
   install: (app) => {
-    const isElectron = import.meta.env.VITE_IS_ELECTRON;
-    let redirectUri = import.meta.env.VITE_APP_AUTH0_REDIRECT_URI;
-    
-    if (isElectron) {
-      redirectUri = 'http://localhost:3009';
-    } else {
-      redirectUri = `${redirectUri}?auth0=true`;
-    }
-
     const auth0 = createAuth0({
       domain: import.meta.env.VITE_APP_AUTH0_DOMAIN,
       clientId: import.meta.env.VITE_APP_AUTH0_CLIENT_ID,
       authorizationParams: {
-        redirect_uri: redirectUri,
+        redirect_uri: `${import.meta.env.VITE_APP_AUTH0_REDIRECT_URI}?auth0=true`,
         audience: import.meta.env.VITE_APP_AUTH0_AUDIENCE,
         organization: import.meta.env.VITE_APP_AUTH0_ORGANIZATION,
         scope: 'openid profile email offline_access'


### PR DESCRIPTION
This pull request refactors authentication handling in the Electron desktop app and improves integration with the web client for logout and token refresh scenarios. The main change is the migration from a local HTTP callback server for Auth0 authentication to a custom protocol-based approach, which is more secure and robust for desktop applications. Additionally, the Electron preload script now exposes an API for renderer processes, and the web client is updated to correctly reload the main window after logout when running inside Electron.

**Electron Desktop App: Authentication Refactor & Protocol Handling**

* Migrated from a local HTTP server (`createAuthCallbackServer`) to a custom protocol handler (`cyoda-desktop://`) for Auth0 authentication callbacks, including support for single-instance locking and cross-platform (Windows/macOS) URL handling. [[1]](diffhunk://#diff-b5fdf212ac943ccb0bf8286b61235e8a38f7719e949e42b534fa9ab51b33c65aL1-R77) [[2]](diffhunk://#diff-b5fdf212ac943ccb0bf8286b61235e8a38f7719e949e42b534fa9ab51b33c65aL111-L113) [[3]](diffhunk://#diff-b5fdf212ac943ccb0bf8286b61235e8a38f7719e949e42b534fa9ab51b33c65aR156-L140) [[4]](diffhunk://#diff-b5fdf212ac943ccb0bf8286b61235e8a38f7719e949e42b534fa9ab51b33c65aR185-R194)
* Added support for processing authentication callback URLs on app startup and when a second instance is launched with an auth callback.
* Implemented an IPC handler (`reload-main-window`) to allow the renderer process to request a reload of the main window.

**Electron Preload Script: IPC API Exposure**

* Exposed a `reloadMainWindow` function to the renderer process via `window.electronAPI`, enabling the web client to trigger a main window reload through IPC.

**Web Client: Electron Integration for Logout/Refresh**

* Refactored the token refresh logic so that on logout (or token refresh failure), if running inside Electron, the renderer requests the main window to reload via the new IPC API instead of redirecting via `window.location`. [[1]](diffhunk://#diff-37df9a3d2e85bae81ad07b0432b6642bdd7101a0b5f31c6257f9c146dc3cc1daR9-R20) [[2]](diffhunk://#diff-37df9a3d2e85bae81ad07b0432b6642bdd7101a0b5f31c6257f9c146dc3cc1daL29-R41) [[3]](diffhunk://#diff-37df9a3d2e85bae81ad07b0432b6642bdd7101a0b5f31c6257f9c146dc3cc1daL50-R67)
* Simplified Auth0 plugin configuration to always use a consistent redirect URI with `?auth0=true` (removing the old localhost:3009 logic).

These changes collectively modernize and harden the authentication flow for the Electron desktop app, providing a more native and reliable user experience.