### PR TITLE
feat: 155 | Add Support for Additional File Formats

### DIFF
--- a/packages/web/src/helpers/HelperUpload.ts
+++ b/packages/web/src/helpers/HelperUpload.ts
@@ -1,32 +1,73 @@
 export default class HelperUpload {
-  static validateFile(file) {
+  static validateFile(file: File) {
     const MAX_TEXT_FILE_SIZE_MB = 2;
     const MAX_IMAGE_FILE_SIZE_MB = 10;
 
-    const TEXT_FILE_TYPES = [
-      "application/pdf",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      "application/xml",
-      "application/json",
+    const SUPPORTED_TEXT_EXTENSIONS = [
+      // Documents
+      ".pdf", ".docx", ".xlsx", ".pptx", ".xml", ".json", ".txt",
+
+      // Configuration
+      ".yml", ".yaml", ".toml", ".ini", ".cfg", ".conf", ".properties", ".env",
+
+      // Documentation / Markup
+      ".md", ".markdown", ".rst", ".tex", ".latex", ".sql",
+
+      // System / Build
+      "dockerfile", ".dockerfile", ".gitignore", ".gitattributes",
+      ".editorconfig", ".htaccess", ".robots",
+      "makefile", ".makefile", ".mk", ".cmake", ".gradle",
+
+      // Programming Languages
+      // Web
+      ".js", ".ts", ".jsx", ".tsx",
+      // Systems
+      ".c", ".cpp", ".h", ".hpp", ".cs", ".rs", ".go",
+      // Mobile
+      ".swift", ".dart",
+      // Functional
+      ".hs", ".ml", ".fs", ".clj", ".elm",
+      // Scientific
+      ".r", ".jl", ".f90", ".f95",
+      // Other
+      ".php", ".rb", ".scala", ".lua", ".nim", ".zig", ".v",
+      ".d", ".cr", ".ex", ".exs", ".erl", ".hrl"
+    ];
+
+    const SUPPORTED_IMAGE_EXTENSIONS = [
+      ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".svg", ".ico"
     ];
 
     if (!file) {
       return { isValid: false, message: "The file is missing." };
     }
 
-    const fileType = file.type;
+    const fileName = file.name.toLowerCase();
     const fileSizeMB = file.size / (1024 * 1024);
 
-    if (TEXT_FILE_TYPES.includes(fileType) || fileType.startsWith("text/")) {
+    // Check if file is supported text file by extension
+    const isTextFileSupported = SUPPORTED_TEXT_EXTENSIONS.some(ext => {
+      if (ext.startsWith('.')) {
+        return fileName.endsWith(ext);
+      } else {
+        // Handle files without extension like 'dockerfile', 'makefile'
+        return fileName === ext || fileName.endsWith('/' + ext);
+      }
+    });
+
+    // Check if file is supported image by extension
+    const isImageFileSupported = SUPPORTED_IMAGE_EXTENSIONS.some(ext => 
+      fileName.endsWith(ext)
+    );
+
+    if (isTextFileSupported) {
       if (fileSizeMB > MAX_TEXT_FILE_SIZE_MB) {
         return { isValid: false, message: `The text file size exceeds ${MAX_TEXT_FILE_SIZE_MB} MB.` };
       }
       return { isValid: true, message: "The file is valid as a text file." };
     }
 
-    if (fileType.startsWith("image/")) {
+    if (isImageFileSupported) {
       if (fileSizeMB > MAX_IMAGE_FILE_SIZE_MB) {
         return { isValid: false, message: `The image size exceeds ${MAX_IMAGE_FILE_SIZE_MB} MB.` };
       }


### PR DESCRIPTION
This pull request refactors the file validation logic in `HelperUpload.ts` to improve how supported file types are detected and validated. Instead of relying on MIME types, the code now checks file extensions to determine if a file is a supported text or image type, and expands the range of supported text file formats.

**File type detection and validation improvements:**

* Replaced MIME type checks with extension-based validation for both text and image files, allowing for more reliable detection of supported formats, including files without extensions.
* Expanded the list of supported text file extensions to include a wide variety of document, configuration, markup, system, and programming language files.
* Expanded the list of supported image file extensions for broader compatibility.

**Code quality improvements:**

* Added explicit TypeScript typing to the `validateFile` method for better type safety (`file: File`).