### PR TITLE
feat: 153 | refine chat blocking and notification handling logic

### DIFF
--- a/packages/web/src/views/ChatBotView.vue
+++ b/packages/web/src/views/ChatBotView.vue
@@ -127,12 +127,12 @@ async function loadChatHistory(id = null) {
       const result = addMessage(el);
       newResults.push(result);
     })
-    if (messages.value[messages.value.length - 1]?.type !== 'answer') isLoading.value = false;
+    if (['question','ui_function'].includes(messages.value[messages.value.length - 1]?.type)) isLoading.value = false;
   } finally {
     promiseInterval = null;
   }
 
-  if (!isFirstRequest && messages.value[messages.value.length - 1]?.type !== 'answer') countNewMessages.value += newResults.filter(el => el).length;
+  if (!isFirstRequest && ['question','ui_function'].includes(messages.value[messages.value.length - 1]?.type)) countNewMessages.value += newResults.filter(el => el).length;
   return newResults.some(el => el);
 }
 


### PR DESCRIPTION
This pull request updates the logic for tracking message types in the chat history loader. The main change is broadening the conditions to include both `question` and `ui_function` message types, instead of just `answer`, when updating loading state and counting new messages.

Message handling improvements:

* Updated the checks in `loadChatHistory` to set `isLoading` to `false` and increment `countNewMessages` when the last message is of type `question` or `ui_function`, rather than only when it is not an `answer`. (`packages/web/src/views/ChatBotView.vue`, [packages/web/src/views/ChatBotView.vueL130-R135](diffhunk://#diff-c6185e121cb68ab7b68b6a523098db77d7c495973e67ed4b386c6ba9ea3b2f94L130-R135))