### PR TITLE
feat: 145 | unlock the chat if workflows are restarted

### DIFF
--- a/packages/web/src/views/ChatBotView.vue
+++ b/packages/web/src/views/ChatBotView.vue
@@ -223,12 +223,10 @@ function startEnvelopeFlash() {
 }
 
 async function onRollback() {
-  isLoading.value = true;
+  isLoading.value = false;
   isLoadingRollback.value = true;
   try {
     await assistantStore.postRollback(technicalId.value);
-  } catch {
-    isLoading.value = false;
   } finally {
     isLoadingRollback.value = false;
   }


### PR DESCRIPTION
This pull request makes a minor adjustment to the loading state logic in the `onRollback` function within `ChatBotView.vue`. The change ensures that the main loading indicator is not activated when a rollback is initiated.

* Updated `onRollback` to set `isLoading.value` to `false` instead of `true`, preventing the main loading state from being triggered during rollback actions.